### PR TITLE
Remove unnecessary print from get_tlds

### DIFF
--- a/domain_parser/domain_parser.py
+++ b/domain_parser/domain_parser.py
@@ -34,8 +34,6 @@ def get_tlds():
     with open('.tlds.pickle', 'w') as outfile:
         pickle.dump(tlds, outfile)
 
-    import pprint
-    pprint.pprint(tlds)
     return tlds
 
 def parse_domain(url):


### PR DESCRIPTION
People probably don't want the list of TLDs to spew out in the middle of their code!
