### PR TITLE
Added support for parsing domains with "https" scheme

### DIFF
--- a/domain_parser/domain_parser.py
+++ b/domain_parser/domain_parser.py
@@ -48,7 +48,7 @@ def parse_domain(url):
     unrecognizable TLD, assumes it is one level.
     """
 
-    if not url.startswith('http://'):
+    if not (url.startswith('http://') or url.startswith('https://')):
         url = 'http://' + url
     top_level_domains = get_tlds()
     parsed = urlparse(url.lower())

--- a/tests/test_domain_parser.py
+++ b/tests/test_domain_parser.py
@@ -18,3 +18,8 @@ class DomainParserTestCase(unittest.TestCase):
         """Is 'www.google.com', which doesn't include the scheme ('http'), parsed properly?"""
         assert domain_parser.parse_domain(
                 'www.google.com') == ('com', 'google', 'www')
+
+    def test_secure_scheme(self):
+        """Is 'https://www.google.com', which include 'https' instead of 'http', parsed properly?"""
+        assert domain_parser.parse_domain(
+                'https://www.google.com') == ('com', 'google', 'www')


### PR DESCRIPTION
Currently, if a domain starts with `https` instead of `http`, the parser would fail to parse it. I've added the simple necessary condition to make domains with `https` be parsed correctly as well. 
