### PR TITLE
Fix encoding of parsed internationalized domain names

### DIFF
--- a/domain_parser/domain_parser.py
+++ b/domain_parser/domain_parser.py
@@ -44,13 +44,16 @@ def get_tlds():
     return tlds
 
 @pylru.lrudecorator(10000)
-def parse_domain(url):
+def parse_domain(url, encoding='utf-8'):
     """Return a tuple containing any subdomains, the second-level domain, and
     the top-level domain for a given URI.
 
     Uses a list of active top-level domains to ensure long TLD's such as
     '.co.uk' are correctly treated as a single TLD.  If the domain has an
     unrecognizable TLD, assumes it is one level.
+
+    The optional encoding argument defaults to 'utf-8' and sets the encoding
+    for the output strings.  Has no effect when running with Python 3.
     """
 
     if not (url.startswith('http://') or url.startswith('https://')):
@@ -75,7 +78,11 @@ def parse_domain(url):
     second_level_domain = ''.join(uri[tld_index-1:tld_index])
     subdomains = '.'.join(uri[:tld_index-1])
 
-    return tld if python_version else tld.encode('utf-8'),\
-     str(second_level_domain), subdomains
+    if python_version:
+        return tld, second_level_domain, subdomains
+    else:
+        return tld.encode(encoding),\
+               second_level_domain.encode(encoding),\
+               subdomains.encode(encoding)
 
 TLD_CACHE = get_tlds()

--- a/tests/test_domain_parser.py
+++ b/tests/test_domain_parser.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import unittest
 
 from domain_parser import domain_parser
@@ -23,3 +24,9 @@ class DomainParserTestCase(unittest.TestCase):
         """Is 'https://www.google.com', which include 'https' instead of 'http', parsed properly?"""
         assert domain_parser.parse_domain(
                 'https://www.google.com') == ('com', 'google', 'www')
+
+    def test_internationalized_domain_name(self):
+        """Is 'маил.гоогле.рф', which is entirely composed of non-latin characters, parsed properly?"""
+        # Should always pass when run with Python 3.
+        assert domain_parser.parse_domain(
+                'http://маил.гоогле.рф') == ('рф', 'гоогле', 'маил')


### PR DESCRIPTION
Currently, when run with Python 2 `parse_domain` returns three strings:
- `tld.encode('utf-8')`: a `utf-8` encoded byte string,
- `str(second_level_domain)`: a byte string encoded with `sys.getdefaultencoding()`, which is ASCII unless it has been set otherwise,
- `subdomains`: a Unicode string.

This results in an exception when trying to parse a domain name whose second level part contains some non-latin characters, like 'маил.гоогле.рф'. Furthermore, Python 2's automatic ASCII encoding means that the end user might incur in some subtle bugs if she is expecting `subdomains` to be a byte string.

This patch makes `parse_domain` return three byte strings encoded with a given encoding, which defaults to the safest choice, `utf-8`, and adds a test that checks that domain names containing non-latin codes are properly parsed.

P.S.: This is my very first pull-request, so could you please let me know if I did everything properly?
